### PR TITLE
update for boot 2.0.0-rc1 "tempdirs"

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,26 +1,27 @@
 (set-env!
  :src-paths    #{"src"}
- :dependencies '[[org.clojure/clojure       "1.6.0"       :scope "provided"]
-                 [boot/core                 "2.0.0-pre9"  :scope "provided"]
-                 [tailrecursion/boot-useful "0.1.3"       :scope "test"]])
+ :dependencies '[[org.clojure/clojure "1.6.0"     :scope "provided"]
+                 [boot/core           "2.0.0-rc1" :scope "provided"]
+                 [adzerk/bootlaces    "0.1.5"     :scope "test"]])
 
 (require
- '[tailrecursion.boot-useful :refer :all]
- '[boot.pod                  :as pod]
- '[boot.util                 :as util]
- '[boot.core                 :as core])
+ '[adzerk.bootlaces :refer :all]
+ '[boot.pod         :as pod]
+ '[boot.util        :as util]
+ '[boot.core        :as core])
 
 (def +version+ "0.2.0")
 
-(useful! +version+)
+(bootlaces! +version+)
 
 (task-options!
- pom [:project 'pandeiro/boot-http
+ pom {:project 'pandeiro/boot-http
       :version +version+
       :description "Boot task to serve a directory over HTTP."
       :url         "https://github.com/pandeiro/boot-http"
       :scm         {:url "https://github.com/pandeiro/boot-http"}
       :license     {:name "Eclipse Public License"
-                    :url  "http://www.eclipse.org/legal/epl-v10.html"}])
+                    :url  "http://www.eclipse.org/legal/epl-v10.html"}})
 
+(require '[pandeiro.http :refer :all])
 


### PR DESCRIPTION
- pod/eval-in => pod/with-eval-in
- seed the worker pod with (core/get-env) + #'pandeiro.http/deps
- the event object is now a Fileset, which with-pre-wrap must explicitly
  accept and return
