### PR TITLE
Use post-wrap, add delay, minor name changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ boot -d pandeiro/boot-http serve -h # show serve's usage
 ### Within a project
 
 If you already have a `build.boot`, add `[pandeiro/boot-http "0.4.0"]` to `:dependencies` and
-`(require '[pandeiro.http :refer :all])`. Then the command is shorter, e.g.:
+`(require '[pandeiro.boot-http :refer :all])`. Then the command is shorter, e.g.:
 
 ```bash
 boot serve -d target wait

--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -1,4 +1,4 @@
-(ns pandeiro.http.impl
+(ns pandeiro.boot-http.impl
   (:import  [java.net URLDecoder])
   (:require [clojure.java.io :as io]
             [clojure.string  :as s]


### PR DESCRIPTION
- Use with-post-wrap because task only reads and doesn't add anything to
  the fileset. This makes it so the task can appear anywhere in the
  pipeline; it's not sensitive to task ordering.

- Use delay to ensure that the server is only started once per pipeline
  (eg so the watch task doesn't start multiple servers every time the
  source files change).

- Change names to boot-http from http for consistency with other tasks.