### PR TITLE
Resource fixes and some refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,35 @@ boot -d pandeiro/boot-http serve -h # show serve's usage
 ### Within a project
 
 If you already have a `build.boot`, add `[pandeiro/boot-http "0.4.0"]` to `:dependencies` and
-`(require '[pandeiro.boot-http :refer :all])`. Then the command is shorter, e.g.:
+`(require '[pandeiro.boot-http :refer :all])`.
+
+You can use boot-http for three different use cases:
+
+#### 1. Serve classpath resources
+
+```bash
+boot serve wait
+# or from build.boot or repl
+(serve)
+```
+
+#### 2. Serve files on choosen directory
 
 ```bash
 boot serve -d target wait
+# or
+(serve :dir "target")
 ```
 
 That would serve the `target` directory if it exists. Instead of specifying a directory,
 you can also specify a ring handler:
 
+#### 3. Start server with given Ring handler
+
 ```bash
 boot serve -H myapp.server/app wait
+or
+(serve :handler 'myapp.server/app)
 ```
 
 ### Composability
@@ -51,7 +69,14 @@ In [boot-cljs-example][boot-cljs-example], for example, `serve` is
 invoked like so:
 
 ```bash
-boot serve -d target/ watch speak reload cljs-repl cljs -usO none
+boot serve watch speak reload cljs-repl cljs -usO none
+# or
+(comp (serve)
+      (watch)
+      (speak)
+      (reload)
+      (cljs-repl)
+      (cljs :optimizations :none))
 ```
 
 In that case, since serve is given a directory, it serves the directory and whatever

--- a/README.md
+++ b/README.md
@@ -91,5 +91,3 @@ your option) any later version.
 [boot-cljs-example]: https://github.com/adzerk/boot-cljs-example
 [installboot]:       https://github.com/boot-clj/boot#install
 [boot-discourse]:    http://hoplon.discoursehosting.net/t/boot-http-0-4-0/361
-
-

--- a/build.boot
+++ b/build.boot
@@ -21,7 +21,3 @@
       :scm         {:url "https://github.com/pandeiro/boot-http"}
       :license     {:name "Eclipse Public License"
                     :url  "http://www.eclipse.org/legal/epl-v10.html"}})
-
-(require
- '[pandeiro.http :refer :all])
-

--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -35,4 +35,4 @@
       (util/info "\n<< stopping Jetty... >>\n")
       (pod/with-eval-in serve-worker
         (.stop server)))
-    (core/with-post-wrap fileset @start)))
+    (core/with-pre-wrap fileset @start fileset)))

--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -21,6 +21,7 @@
 
   [d dir     PATH str "The directory to serve."
    H handler SYM  sym "The ring handler to serve."
+   r resource-root ROOT str "The root prefix when serving resources from classpath"
    p port    PORT int "The port to listen on. (Default: 3000)"]
 
   (let [port  (or port default-port)
@@ -28,11 +29,10 @@
                 (pod/with-eval-in serve-worker
                   (require '[pandeiro.boot-http.impl :as http])
                   (def server
-                    (http/server {:dir ~dir, :port ~port, :handler '~handler})))
+                    (http/server {:dir ~dir, :port ~port, :handler '~handler :resource-root ~resource-root})))
                 (util/info "<< started Jetty on http://localhost:%d >>\n" port))]
     (core/cleanup
       (util/info "\n<< stopping Jetty... >>\n")
       (pod/with-eval-in serve-worker
         (.stop server)))
     (core/with-post-wrap fileset @start)))
-

--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -59,13 +59,13 @@
         (wrap-file dir {:index-files? false})
         (wrap-resource ""))))
 
-(defn resources-handler [{:keys [prefix]
-                          :or {prefix ""}}]
+(defn resources-handler [{:keys [resource-root]
+                          :or {resource-root ""}}]
   (-> (fn [{:keys [request-method uri] :as req}]
         (if (and (= request-method :get) (= uri "/"))
-          (some-> (resource-response "index.html" {:root prefix})
+          (some-> (resource-response "index.html" {:root resource-root})
                   (content-type "text/html"))))
-      (wrap-resource prefix)))
+      (wrap-resource resource-root)))
 
 ;;
 ;; Jetty

--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -2,7 +2,12 @@
   (:import  [java.net URLDecoder])
   (:require [clojure.java.io :as io]
             [clojure.string  :as s]
-            [ring.middleware file resource content-type not-modified]
+            [ring.util.response :refer [resource-response content-type]]
+            [ring.middleware
+             [file :refer [wrap-file]]
+             [resource :refer [wrap-resource]]
+             [content-type :refer [wrap-content-type]]
+             [not-modified :refer [wrap-not-modified]]]
             [ring.adapter.jetty :refer [run-jetty]]))
 
 ;;
@@ -43,26 +48,33 @@
 ;;
 ;; Handlers
 ;;
-(defn resources [req]
-  (ring.middleware.resource/resource-request req ""))
+(defn resolve-ring-handler [{:keys [handler]}]
+  (when handler
+    (require (symbol (namespace handler)) :reload)
+    (resolve handler)))
 
-(defn directories-and-resources [dir]
-  (-> (index-for dir)
-    (ring.middleware.file/wrap-file dir {:index-files? false})
-    (ring.middleware.resource/wrap-resource "")))
+(defn dir-handler [{:keys [dir]}]
+  (when dir
+    (-> (index-for dir)
+        (wrap-file dir {:index-files? false})
+        (wrap-resource ""))))
+
+(defn resources-handler [{:keys [prefix]
+                          :or {prefix ""}}]
+  (-> (fn [{:keys [request-method uri] :as req}]
+        (if (and (= request-method :get) (= uri "/"))
+          (some-> (resource-response "index.html" {:root prefix})
+                  (content-type "text/html"))))
+      (wrap-resource prefix)))
 
 ;;
 ;; Jetty
 ;;
-(defn server [{:keys [dir port handler]}]
-  (let [handler (if handler
-                  (do
-                    (require (symbol (namespace handler)) :reload)
-                    (resolve handler))
-                  (if dir
-                    (directories-and-resources dir)
-                    resources))]
+(defn server [{:keys [port] :as opts}]
+  (let [handler (or (resolve-ring-handler opts)
+                    (dir-handler opts)
+                    (resources-handler opts))]
     (run-jetty (-> handler
-                 (ring.middleware.content-type/wrap-content-type)
-                 (ring.middleware.not-modified/wrap-not-modified))
+                   (wrap-content-type)
+                   (wrap-not-modified))
                {:port port :join? false})))


### PR DESCRIPTION
- When serving files from classpath, index.html is served when "/" is requested
- `:resource-root` can be defined to use prefix when serving files from classpath
- Impl namespace now uses `:refer` with ring stuff to clear code a bit
- The handler is created by calling multiple functions with options, the first not-nil value is used as handler.