### PR TITLE
Add -R/--reload flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.2
+
+- Add: -R/--reload flag to reload modified namespaces on each request
+
 # 0.6.1
 
 - Bump HTTP Kit to 2.1.19 to fix RejectedExecutionException

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ that can serve resources, directories or a typical ring handler.
 
 [](dependency)
 ```clojure
-[pandeiro/boot-http "0.6.1"] ;; latest release
+[pandeiro/boot-http "0.6.2"] ;; latest release
 ```
 [](/dependency)
 
@@ -55,7 +55,7 @@ you can also specify a ring handler:
 #### 3. Start server with given Ring handler
 
 ```bash
-boot serve -H myapp.server/app wait   # (boot (serve :handler 'myapp.server/app) (wait))
+boot serve -H myapp.server/app -R wait   # (boot (serve :handler 'myapp.server/app :reload true) (wait))
 ```
 
 ### Composability

--- a/build.boot
+++ b/build.boot
@@ -5,14 +5,15 @@
                  [adzerk/bootlaces        "0.1.9"     :scope "test"]
                  [adzerk/boot-test        "1.0.3"     :scope "test"]
                  [ring/ring-jetty-adapter "1.3.2"     :scope "test"]
-                 [ring/ring-core          "1.3.2"     :scope "test"]])
+                 [ring/ring-core          "1.3.2"     :scope "test"]
+                 [ring/ring-devel         "1.3.2"     :scope "test"]])
 
 (require
  '[adzerk.bootlaces :refer :all] ;; tasks: build-jar push-snapshot push-release
  '[adzerk.boot-test :refer :all]
  '[pandeiro.boot-http :refer :all])
 
-(def +version+ "0.6.1")
+(def +version+ "0.6.2")
 
 (bootlaces! +version+)
 

--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -9,7 +9,8 @@
 (def default-port 3000)
 
 (def serve-deps
-  '[[ring/ring-core "1.3.2"]])
+  '[[ring/ring-core "1.3.2"]
+    [ring/ring-devel "1.3.2"]])
 
 (def jetty-dep
   '[ring/ring-jetty-adapter "1.3.2"])
@@ -31,7 +32,8 @@
    r resource-root ROOT str  "The root prefix when serving resources from classpath"
    p port          PORT int  "The port to listen on. (Default: 3000)"
    k httpkit            bool "Use Http-kit server instead of Jetty"
-   s silent             bool "Silent-mode (don't output anything)"]
+   s silent             bool "Silent-mode (don't output anything)"
+   R reload             bool "Reload modified namespaces on each request."]
 
   (let [port        (or port default-port)
         deps        (conj serve-deps (if httpkit httpkit-dep jetty-dep))
@@ -46,8 +48,9 @@
                          (u/resolve-and-invoke '~init))
                        (def server
                          (http/server
-                          {:dir ~dir, :port ~port, :handler '~handler
-                           :httpkit ~httpkit, :resource-root ~resource-root})))
+                          {:dir ~dir, :port ~port, :handler '~handler,
+                           :reload '~reload, :httpkit ~httpkit,
+                           :resource-root ~resource-root})))
                      (when-not silent
                        (util/info
                         "<< started %s on http://localhost:%d >>\n"


### PR DESCRIPTION
This adds an option to wrap the handler argument in [ring.middleware.reload/wrap-reload][wrap-reload]. With this flag enabled, the server will automatically reload any modified files on each request to the server, which is handy for development.

[wrap-reload]: https://ring-clojure.github.io/ring/ring.middleware.reload.html