### PR TITLE
If dir supplied and dir doesn't exist, create it

### DIFF
--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -25,7 +25,7 @@
   "Start a web server on localhost, serving resources and optionally a directory.
   Listens on port 3000 by default."
 
-  [d dir           PATH str  "The directory to serve."
+  [d dir           PATH str  "The directory to serve; created if doesn't exist."
    H handler       SYM  sym  "The ring handler to serve."
    i init          SYM  sym  "A function to run prior to starting the server."
    c cleanup       SYM  sym  "A function to run after the server stops."

--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -65,9 +65,15 @@
       (wrap-reload (u/resolve-sym handler))
       (u/resolve-sym handler))))
 
+(defn- maybe-create-dir! [dir]
+  (let [dir-file (io/file dir)]
+    (if-not (.exists dir-file)
+      (.mkdir dir-file))))
+
 (defn dir-handler [{:keys [dir resource-root]
                     :or {resource-root ""}}]
   (when dir
+    (maybe-create-dir! dir)
     (-> not-found
       (wrap-resource resource-root)
       (wrap-file dir {:index-files? false})


### PR DESCRIPTION
- helpful when project's target/ doesn't exist yet

I realized this was a problem when I tried to compile @piranha's [snakehop](https://github.com/piranha/snakehop) game for the first time.