### PR TITLE
Use mkdirs instead of mkdir for nested directories.

### DIFF
--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -70,7 +70,7 @@
   (let [dir-file (io/file dir)]
     (when-not (.exists dir-file)
       (warn "Directory '%s' was not found. Creating it..." dir)
-      (.mkdir dir-file))))
+      (.mkdirs dir-file))))
 
 (defn dir-handler [{:keys [dir resource-root]
                     :or {resource-root ""}}]


### PR DESCRIPTION
By the way, thanks for this project.  It's great.

With a recent project I wanted to (serve :dir "target/public/").  When I did, the task failed because the directory did not exist.  So I dug in and noticed the call to [.mkdir](http://docs.oracle.com/javase/7/docs/api/java/io/File.html#mkdir()), which doesn't handle the parent directory creation, whereas mkdirs does.