### PR TITLE
nREPL flag for access to running server state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.7.0
+# 0.7.0-SNAPSHOT
 
 - Add: -n/--nrepl flag for nREPL access to http server
 - Bumped dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.7.0
+
+- Add: -n/--nrepl flag for nREPL access to http server
+- Bumped dependencies
+
 # 0.6.3
 
 - Add: automatic handling of slashes on index.html resources

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Use the HTTP Kit webserver instead of Jetty.
 boot -d pandeiro/boot-http serve -d . -k wait  # uses httpkit
 ```
 
-#### -n / --nrepl
+#### -n / --nrepl (Added in 0.7.0-SNAPSHOT release)
 
 Start an nREPL server for access to the http server. Accepts
 ```:port``` and ```:bind``` options for setting nREPL server IP

--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ Use the HTTP Kit webserver instead of Jetty.
 boot -d pandeiro/boot-http serve -d . -k wait  # uses httpkit
 ```
 
+#### -n / --nrepl
+
+Start an nREPL server for access to the http server. Accepts
+```:port``` and ```:bind``` options for setting nREPL server IP
+and port.
+
+```bash
+boot -d pandeiro/boot-http serve -d . -n "{:port 3001}"
+```
+
 #### -i / --init and -c / --cleanup
 
 Setup and teardown functions to run.

--- a/build.boot
+++ b/build.boot
@@ -14,7 +14,7 @@
  '[adzerk.boot-test :refer :all]
  '[pandeiro.boot-http :refer :all])
 
-(def +version+ "0.7.0")
+(def +version+ "0.7.0-SNAPSHOT")
 
 (bootlaces! +version+)
 

--- a/build.boot
+++ b/build.boot
@@ -1,19 +1,20 @@
 (set-env!
  :source-paths #{"src" "test"}
- :dependencies '[[org.clojure/clojure     "1.6.0" :scope "provided"]
-                 [boot/core               "2.1.2" :scope "provided"]
-                 [adzerk/bootlaces        "0.1.9" :scope "test"]
-                 [adzerk/boot-test        "1.0.3" :scope "test"]
-                 [ring/ring-jetty-adapter "1.3.2" :scope "test"]
-                 [ring/ring-core          "1.3.2" :scope "test"]
-                 [ring/ring-devel         "1.3.2" :scope "test"]])
+ :dependencies '[[org.clojure/clojure     "1.7.0"  :scope "provided"]
+                 [boot/core               "2.3.0"  :scope "provided"]
+                 [adzerk/bootlaces        "0.1.12"  :scope "test"]
+                 [adzerk/boot-test        "1.0.4"  :scope "test"]
+                 [ring/ring-jetty-adapter "1.4.0"  :scope "test"]
+                 [ring/ring-core          "1.4.0"  :scope "test"]
+                 [ring/ring-devel         "1.4.0"  :scope "test"]
+                 [org.clojure/tools.nrepl "0.2.11" :scope "test"]])
 
 (require
  '[adzerk.bootlaces :refer :all] ;; tasks: build-jar push-snapshot push-release
  '[adzerk.boot-test :refer :all]
  '[pandeiro.boot-http :refer :all])
 
-(def +version+ "0.6.3")
+(def +version+ "0.7.0")
 
 (bootlaces! +version+)
 

--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -33,7 +33,8 @@
    p port          PORT int  "The port to listen on. (Default: 3000)"
    k httpkit            bool "Use Http-kit server instead of Jetty"
    s silent             bool "Silent-mode (don't output anything)"
-   R reload             bool "Reload modified namespaces on each request."]
+   R reload             bool "Reload modified namespaces on each request."
+   n nrepl         REPL edn  "nREPL server parameters e.g. \"{:port 3001}\""]
 
   (let [port        (or port default-port)
         deps        (conj serve-deps (if httpkit httpkit-dep jetty-dep))
@@ -43,14 +44,23 @@
         start       (delay
                      (pod/with-eval-in worker
                        (require '[pandeiro.boot-http.impl :as http]
-                                '[pandeiro.boot-http.util :as u])
+                                '[pandeiro.boot-http.util :as u]
+                                '[clojure.tools.nrepl.server :refer [start-server]])
                        (when '~init
                          (u/resolve-and-invoke '~init))
                        (def server
                          (http/server
                           {:dir ~dir, :port ~port, :handler '~handler,
                            :reload '~reload, :httpkit ~httpkit,
-                           :resource-root ~resource-root})))
+                           :resource-root ~resource-root}))
+                       (def repl-server
+                         (if ~nrepl
+                           (let [bind (if (:bind ~nrepl) (:bind ~nrepl) "127.0.0.1")
+                                 repl-server (if (:port ~nrepl)
+                                               (start-server :port (:port ~nrepl) :bind bind)
+                                               (start-server :bind bind))]
+                             (println "boot-http nREPL started on " bind " port " (:port repl-server))
+                             repl-server))))
                      (when-not silent
                        (util/info
                         "<< started %s on http://localhost:%d >>\n"
@@ -61,7 +71,10 @@
      (pod/with-eval-in worker
        (when server
          (when-not silent
-           (util/info "<< stopping %s... >>\n" server-name))))
+           (util/info "<< stopping %s... >>\n" server-name)))
+       (when repl-server
+         (println "stopping boot-http nREPL server")
+         (.stop repl-server)))
      (pod/with-eval-in worker
        (if ~httpkit
          (server)


### PR DESCRIPTION
Added nREPL functionality:

Valid command line usage:
boot serve -n {}
boot serve -n “{:port 3001}”
boot serve -n “{:port 3001 :bind \“0.0.0.0\”}”

Valid repl usage:
(boot (serve :nrepl {:port 2999}) (wait))

Also bumped dependencies to most recent versions and updated version to 0.7.0 to reflect backwards-compatible API change