### PR TITLE
pass env dirs to wrap-reload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: clojure
 jdk:
   - oraclejdk8
 install:
-  - wget -O boot https://github.com/boot-clj/boot/releases/download/2.3.0/boot.sh
+  - wget -O boot https://github.com/boot-clj/boot/releases/download/2.4.0/boot.sh
   - chmod 755 boot
   - ./boot -V
 script:

--- a/boot.properties
+++ b/boot.properties
@@ -1,0 +1,6 @@
+#https://github.com/boot-clj/boot
+#Tue Oct 27 17:06:06 EDT 2015
+BOOT_JVM_OPTIONS=-client -XX\:+TieredCompilation -XX\:TieredStopAtLevel\=1 -Xmx2g -XX\:+UseConcMarkSweepGC -XX\:+CMSClassUnloadingEnabled -Xverify\:none
+BOOT_CLOJURE_NAME=org.clojure/clojure
+BOOT_VERSION=2.4.2
+BOOT_CLOJURE_VERSION=1.7.0

--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -47,6 +47,7 @@
         worker      (pod/make-pod (update-in (core/get-env) [:dependencies]
                                              into deps))
         server-name (if httpkit "HTTP Kit" "Jetty")
+        env-dirs    (vec (core/get-env :directories))
         start       (delay
                      (pod/with-eval-in worker
                        (require '[pandeiro.boot-http.impl :as http]
@@ -56,7 +57,7 @@
                        (def server
                          (http/server
                           {:dir ~dir, :port ~port, :handler '~handler,
-                           :reload '~reload, :httpkit ~httpkit,
+                           :reload '~reload, :env-dirs ~env-dirs, :httpkit ~httpkit,
                            :resource-root ~resource-root}))
                        (def nrepl-server
                          (when ~nrepl

--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -47,7 +47,7 @@
         worker      (pod/make-pod (update-in (core/get-env) [:dependencies]
                                              into deps))
         server-name (if httpkit "HTTP Kit" "Jetty")
-        env-dirs    (vec (core/get-env :directories))
+        env-dirs    (vec (core/get-env :source-paths))
         start       (delay
                      (pod/with-eval-in worker
                        (require '[pandeiro.boot-http.impl :as http]

--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -47,7 +47,6 @@
         worker      (pod/make-pod (update-in (core/get-env) [:dependencies]
                                              into deps))
         server-name (if httpkit "HTTP Kit" "Jetty")
-        env-dirs    (vec (core/get-env :source-paths))
         start       (delay
                      (pod/with-eval-in worker
                        (require '[pandeiro.boot-http.impl :as http]
@@ -57,7 +56,7 @@
                        (def server
                          (http/server
                           {:dir ~dir, :port ~port, :handler '~handler,
-                           :reload '~reload, :env-dirs ~env-dirs, :httpkit ~httpkit,
+                           :reload '~reload, :env-dirs ~(vec (:directories pod/env)), :httpkit ~httpkit,
                            :resource-root ~resource-root}))
                        (def nrepl-server
                          (when ~nrepl

--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -60,10 +60,10 @@
    :headers {"Content-Type" "text/plain; charset=utf-8"}
    :body    "Not found"})
 
-(defn ring-handler [{:keys [handler reload]}]
+(defn ring-handler [{:keys [handler reload env-dirs]}]
   (when handler
     (if reload
-      (wrap-reload (u/resolve-sym handler))
+      (wrap-reload (u/resolve-sym handler) {:dirs (or env-dirs ["src"])})
       (u/resolve-sym handler))))
 
 (defn- maybe-create-dir! [dir]


### PR DESCRIPTION
I noticed that reloading doesn't work unless your source directory starts with `src`. @Deraen pointed out that this is because `boot-http` calls `wrap-reload` without specifying the `:dirs` option, so it defaults to only reloading things under `src`. This patch feeds the `:directories` from the boot environment into the call to `wrap-reload` so that reloading will work for whatever source directories are configured.