### PR TITLE
Add option for providing a custom 404 handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,15 @@ boot serve wait   # or from REPL: (boot (serve) (wait))
 boot serve -d target wait   # or at the REPL: (boot (serve :dir "target") (wait))
 ```
 
-That would serve the `target` directory if it exists. Instead of specifying a directory,
-you can also specify a ring handler:
+That would serve the `target` directory if it exists.
+
+Sometimes it is useful to customize the handling of 404s. This can be done by providing a ring handler as the `not-found` option:
+
+```bash
+boot serve -d target -N custom-not-found wait # (boot (serve :dir "target" :not-found "custom-not-found") (wait))
+```
+
+Instead of specifying a directory, you can also specify a ring handler:
 
 #### 3. Start server with given Ring handler
 

--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -37,7 +37,8 @@
    k httpkit            bool "Use Http-kit server instead of Jetty"
    s silent             bool "Silent-mode (don't output anything)"
    R reload             bool "Reload modified namespaces on each request."
-   n nrepl         REPL edn  "nREPL server parameters e.g. \"{:port 3001, :bind \"0.0.0.0\"}\""]
+   n nrepl         REPL edn  "nREPL server parameters e.g. \"{:port 3001, :bind \"0.0.0.0\"}\""
+   N not-found     SYM  sym "a ring handler for requested resources that aren't in your directory. Useful for pushState."]
 
   (let [port        (or port default-port)
         server-dep  (if httpkit httpkit-dep jetty-dep)
@@ -57,6 +58,7 @@
                          (http/server
                           {:dir ~dir, :port ~port, :handler '~handler,
                            :reload '~reload, :env-dirs ~(vec (:directories pod/env)), :httpkit ~httpkit,
+                           :not-found '~not-found,
                            :resource-root ~resource-root}))
                        (def nrepl-server
                          (when ~nrepl

--- a/test/pandeiro/boot_http_tests.clj
+++ b/test/pandeiro/boot_http_tests.clj
@@ -1,7 +1,7 @@
 (ns pandeiro.boot-http-tests
   (:require [clojure.test :refer :all]
             [clojure.java.io :as io]
-            [pandeiro.boot-http.impl :refer :all]
+            [pandeiro.boot-http.impl :refer [dir-handler index-file-exists?]]
             [pandeiro.boot-http.util :as u]))
 
 (deftest detect-index-files
@@ -23,3 +23,14 @@
   (testing "can invoke ns-qualified functions"
     (is (= :sample
            (u/resolve-and-invoke 'pandeiro.boot-http-tests-sample/sample-fn)))))
+
+(defn teapot-app [request]
+  {:status 418})
+
+(deftest not-found-handler
+  (let [req {:uri "/missing"}]
+    (testing "is called when serving a directory"
+      (is (= 404
+             (:status ((dir-handler {:dir "public"}) req))))
+      (is (= 418
+             (:status ((dir-handler {:dir "public" :not-found `teapot-app}) req)))))))


### PR DESCRIPTION
This is for issue #23. It allows the specification of a custom 404 handler.

Here is an example:

```clojure
(deftask dev []
  (comp
    (serve :not-found 'history-app :dir "target" :reload true)
    ...
   ))
```

And a handler that returns the main document on 404:

```clojure
(defn history-app [request]
  (assoc-in
    (file-response "target/index.html")
    [:headers "Content-Type"]
    "text/html;charset=utf8"))
```