### PR TITLE
Feature/make port available to other tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ resources can be found on the classpath, and then gets out of the way.
 
 #### -p / --port
 
-Use a specific port.
+Use a specific port. A value of `0` will automatically bind to a free port.
+The actual port number being used is available as `:http-port` on the fileset.
 
 ```bash
 boot -d pandeiro/boot-http serve -d . -p 8888 wait

--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -81,4 +81,4 @@
          (u/resolve-and-invoke '~cleanup))))
     (core/with-pre-wrap fileset
       @start
-      fileset)))
+      (assoc fileset :http-port (pod/with-eval-in worker (:local-port server))))))

--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -60,7 +60,7 @@
    :headers {"Content-Type" "text/plain; charset=utf-8"}
    :body    "Not found"})
 
-(defn ring-handler [{:keys [handler reload env-dirs]}]
+(defn wrap-handler [{:keys [handler reload env-dirs]}]
   (when handler
     (if reload
       (wrap-reload (u/resolve-sym handler) {:dirs (or env-dirs ["src"])})
@@ -92,23 +92,36 @@
                     (content-type "text/html")))))
       (wrap-resource resource-root)))
 
+(defn ring-handler [opts]
+  (or (wrap-handler opts)
+      (dir-handler opts)
+      (resources-handler opts)))
+
 ;;
 ;; Jetty / HTTP Kit
 ;;
+
+(defn- start-httpkit [handler opts]
+  (require 'org.httpkit.server)
+  (let [stop-server ((resolve 'org.httpkit.server/run-server) handler opts)]
+    (merge (meta stop-server)
+           {:stop-server stop-server
+            :human-name "HTTP Kit"})))
+
+(defn- start-jetty [handler opts]
+  (require 'ring.adapter.jetty)
+  (let [server ((resolve 'ring.adapter.jetty/run-jetty) handler opts)]
+    {:server server
+     :human-name "Jetty"
+     :local-port (-> server (.getConnectors) (first) (.getLocalPort))
+     :stop-server #(.stop server)}))
+
 (defn server [{:keys [port httpkit] :as opts}]
-  (if httpkit
-    (require 'org.httpkit.server)
-    (require 'ring.adapter.jetty))
-  (let [handler (or (ring-handler opts)
-                    (dir-handler opts)
-                    (resources-handler opts))
-        run     (if httpkit
-                  (resolve 'org.httpkit.server/run-server)
-                  (resolve 'ring.adapter.jetty/run-jetty))]
-    (run (-> handler
-           (wrap-content-type)
-           (wrap-not-modified))
-      {:port port :join? false})))
+  ((if httpkit start-httpkit start-jetty)
+   (-> (ring-handler opts)
+       (wrap-content-type)
+       (wrap-not-modified))
+   {:port port :join? false}))
 
 ;;
 ;; nREPL


### PR DESCRIPTION
This will make the actual port being used available to other tasks through `:http-port` on the `fileset`. That way it is now possible to pass an option of `--port 0` and make the task autodetect a random free port. See https://github.com/pandeiro/boot-http/issues/34 for a preceding discussion.

I also did some refactoring in order to pass the information from the `http/server` call in a clean way and get rid of `httpkit` branching all over the place.