### PR TITLE
Make port number accessible to subsequent tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ resources can be found on the classpath, and then gets out of the way.
 
 #### -p / --port
 
-Use a specific port.
+Use a specific port. A value of `0` will automatically bind to a free port.
 
 ```bash
 boot -d pandeiro/boot-http serve -d . -p 8888 wait


### PR DESCRIPTION
Extracted from https://github.com/pandeiro/boot-http/pull/36

This PR heavily depends on the refactoring from https://github.com/pandeiro/boot-http/pull/37. Therefore it incorporates those changes as well and ought to be merged after.