### PR TITLE
add option to set ip address or host

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ that can serve resources, directories or a typical ring handler.
 
 [](dependency)
 ```clojure
-[pandeiro/boot-http "0.7.3"] ;; latest release
+[pandeiro/boot-http "0.7.4-SNAPSHOT"] ;; latest release
 ```
 [](/dependency)
 

--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -34,6 +34,7 @@
    c cleanup       SYM  sym  "A function to run after the server stops."
    r resource-root ROOT str  "The root prefix when serving resources from classpath"
    p port          PORT int  "The port to listen on. (Default: 3000)"
+   I ip-or-host    HOST str  "The ip or host to listen on."
    k httpkit            bool "Use Http-kit server instead of Jetty"
    s silent             bool "Silent-mode (don't output anything)"
    R reload             bool "Reload modified namespaces on each request."
@@ -57,6 +58,7 @@
                        (def server
                          (http/server
                           {:dir ~dir, :port ~port, :handler '~handler,
+                           :host ~ip-or-host
                            :reload '~reload, :env-dirs ~(vec (:directories pod/env)), :httpkit ~httpkit,
                            :not-found '~not-found,
                            :resource-root ~resource-root}))

--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -119,12 +119,12 @@
      :local-port (-> server .getConnectors first .getLocalPort)
      :stop-server #(.stop server)}))
 
-(defn server [{:keys [port httpkit] :as opts}]
+(defn server [{:keys [host port httpkit] :as opts}]
   ((if httpkit start-httpkit start-jetty)
    (-> (ring-handler opts)
        wrap-content-type
        wrap-not-modified)
-   {:port port :join? false}))
+   {:ip host :host host :port port :join? false}))
 
 ;;
 ;; nREPL


### PR DESCRIPTION
I saw a question on Slack about whether it's possible to set ip address that server binds to and so I threw this together quickly. This should work for jetty and http-kit. jetty uses the `:host` option and http-kit uses the `:ip` option. Feel free to merge if you think it'd be good option to provide. Otherwise, it might be better to take a step back and provide a more general way to pass options thru to the server impl (either to http-kit or jetty). 