### PR TITLE
Fix #25 and fix #56 - shut down Jetty and nrepl on cleanup

### DIFF
--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -98,12 +98,12 @@
     (core/cleanup
      (pod/with-eval-in worker
        (when nrepl-server
-         (when-not silent
-           (util/info "Stopping boot-http nREPL server"))
+         (when-not ~silent
+           (boot/info "Stopping boot-http nREPL server"))
          (.stop nrepl-server))
        (when server
-         (when-not silent
-           (util/info "Stopping %s\n" (:human-name server)))
+         (when-not ~silent
+           (boot/info "Stopping %s\n" (:human-name server)))
          ((:stop-server server)))
        (when '~cleanup
          (u/resolve-and-invoke '~cleanup))))


### PR DESCRIPTION
The `silent` parameter wasn't unquoted in the `with-eval-in` body, which resulted in an unknown symbol in the pod's environment. Similarly, the `util` namespace isn't loaded in the pod, so those symbols aren't known either. For whatever reason, both of these errors are swallowed somewhere in `with-eval-in`, which made this problem hard to diagnose, or even to see.