### PR TITLE
wrap-index serves a file instead of slurping it

### DIFF
--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -41,7 +41,7 @@
             {:status  200
              :headers {"Content-Type" "text/html"}
              :body    (if-let [index-file (index-file-exists? files)]
-                        (slurp index-file)
+                        (io/file index-file)
                         (format (str "<!doctype html><meta charset=\"utf-8\">"
                                      "<body><h1>Directory listing</h1><hr>"
                                      "<ul>%s</ul></body>")


### PR DESCRIPTION
This preserves the encoding in the Content-Type header.

With slurp, it seems that jetty is appending `charset=ISO-8859-1` to the Content-Type header.
If `io/file` is used, then it correctly recognizes the contents as utf-8.