### PR TITLE
Always load nrepl deps

### DIFF
--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -58,9 +58,9 @@
                                  (str "Expected map for ssl-props got \"" ssl-props "\"")))
                         (merge ssl-defaults (or ssl-props {}))))
         server-dep  (if httpkit httpkit-dep jetty-dep)
-        deps        (cond-> serve-deps
-                      true               (conj server-dep)
-                      (not (nil? nrepl)) (concat (nrepl-deps)))
+        deps        (-> serve-deps
+                        (conj server-dep)
+                        (concat (nrepl-deps)))
 
         ;; Turn the middleware symbols into strings to prevent an attempt to
         ;; resolve the namespaces when the list is processed in the Boot pod.


### PR DESCRIPTION
boot-http requires `boot.repl-server` in the worker pod, which in
turn requires 3 namespaces under `clojure.tools.nrepl`. Because of
this, boot-http needs to ensure that `org.clojure/tools.nrepl` is
loaded in the worker pod.

This build.boot is sufficient to demonstrate the bug:

```
(set-env!
 :source-paths #{"src"}
 :dependencies '[[pandeiro/boot-http "0.7.6"]])

(require '[pandeiro.boot-http :refer [serve]])
```

Running `boot serve -r public` with this configuration throws a
FileNotFoundException.