### PR TITLE
Use utf-8 as default charset

### DIFF
--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -14,6 +14,7 @@
 
 (def serve-deps
   '[[ring/ring-core "1.4.0"]
+    [ring/ring-headers "0.2.0"]
     [ring/ring-devel "1.4.0"]])
 
 (def jetty-dep

--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -7,6 +7,7 @@
              [file :refer [wrap-file]]
              [resource :refer [wrap-resource]]
              [content-type :refer [wrap-content-type]]
+             [default-charset :refer [wrap-default-charset]]
              [not-modified :refer [wrap-not-modified]]
              [reload :refer [wrap-reload]]]
             [pandeiro.boot-http.util :as u]
@@ -132,7 +133,8 @@
   ((if httpkit start-httpkit start-jetty)
    (-> (ring-handler opts)
        wrap-content-type
-       wrap-not-modified)
+       wrap-not-modified
+       (wrap-default-charset "utf-8"))
     (cond-> {:port  port
              :join? false}
             (seq ssl-props)


### PR DESCRIPTION
This fixes serving utf8 encoded files, e.g. [plotlyjs](https://raw.githubusercontent.com/plotly/plotly.js/master/dist/plotly.js), which contains:

>   var ε = 1e-6, ε2 = ε * ε, π = Math.PI, τ = 2 * π, τε = τ - ε, halfπ = π / 2, d3_radians = π / 180, d3_degrees = 180 / π;
