### PR TITLE
Only load tools.nrepl when needed

### DIFF
--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -60,9 +60,9 @@
                                  (str "Expected map for ssl-props got \"" ssl-props "\"")))
                         (merge ssl-defaults (or ssl-props {}))))
         server-dep  (if httpkit httpkit-dep jetty-dep)
-        deps        (-> serve-deps
-                        (conj server-dep)
-                        (concat (nrepl-deps)))
+        deps        (cond-> serve-deps
+                      true               (conj server-dep)
+                      (not (nil? nrepl)) (concat (nrepl-deps)))
 
         ;; Turn the middleware symbols into strings to prevent an attempt to
         ;; resolve the namespaces when the list is processed in the Boot pod.
@@ -76,8 +76,7 @@
                      (pod/with-eval-in worker
                        (require '[pandeiro.boot-http.impl :as http]
                                 '[pandeiro.boot-http.util :as u]
-                                '[boot.util               :as boot]
-                                '[boot.repl-server        :as rsrv])
+                                '[boot.util               :as boot])
                        (when '~init
                          (u/resolve-and-invoke '~init))
                        (def server
@@ -89,7 +88,7 @@
                            :resource-root ~resource-root}))
                        (def nrepl-server
                          (when ~nrepl
-                           (http/nrepl-server {:nrepl (assoc ~nrepl :middleware (rsrv/->mw-list (map symbol ~middlewares)))})))
+                           (http/nrepl-server {:nrepl (assoc ~nrepl :middleware (map symbol ~middlewares))})))
                        (when-not ~silent
                          (boot/info "Started %s on %s://localhost:%d\n"
                                (:human-name server)

--- a/src/pandeiro/boot_http/impl.clj
+++ b/src/pandeiro/boot_http/impl.clj
@@ -149,10 +149,12 @@
 ;;
 
 (defn nrepl-server [{:keys [nrepl]}]
-  (require 'clojure.tools.nrepl.server)
+  (require '[clojure.tools.nrepl.server]
+           '[boot.repl-server])
   (let [start-server      (resolve 'clojure.tools.nrepl.server/start-server)
         default-handler   (resolve 'clojure.tools.nrepl.server/default-handler)
-        handler           (when-let [mw (:middleware nrepl)]
+        ->mw-list         (resolve 'boot.repl-server/->mw-list)
+        handler           (when-let [mw (->mw-list (:middleware nrepl))]
                             (apply default-handler mw))
         opts              (->> (-> (assoc nrepl :handler handler)
                                    (update :bind #(or % "127.0.0.1")))


### PR DESCRIPTION
This addresses the feedback on https://github.com/pandeiro/boot-http/pull/61.  While it was merged, @pandeiro expressed a desire that tools.nrepl not be loaded if nrepl isn't needed.  To that end, this PR undoes the change in #61, and instead moves the offending require statement from the startup invocation in the worker pod to `pandeiro.boot-http.impl/nrepl-server`.