### PR TITLE
Upgrade ring-core, ring-devel and ring-jetty-adapter from 1.4.0 => 1.7.1

### DIFF
--- a/src/pandeiro/boot_http.clj
+++ b/src/pandeiro/boot_http.clj
@@ -13,12 +13,12 @@
 (def ssl-defaults {:port 3443 :keystore (str (clojure.java.io/resource "boot-http-keystore.jks")) :key-password "p@ssw0rd"})
 
 (def serve-deps
-  '[[ring/ring-core "1.4.0"]
+  '[[ring/ring-core "1.7.1"]
     [ring/ring-headers "0.2.0"]
-    [ring/ring-devel "1.4.0"]])
+    [ring/ring-devel "1.7.1"]])
 
 (def jetty-dep
-  '[ring/ring-jetty-adapter "1.4.0"])
+  '[ring/ring-jetty-adapter "1.7.1"])
 
 (def httpkit-dep
   '[http-kit "2.1.19"])


### PR DESCRIPTION
I'm working on a web app where we need to upgrade Jetty (and by extension, Ring) for security reasons. We use boot-http to serve the app locally for development, and we'd like to be able to use the same versions of Ring there.

I think ideally, there would be a way to specify what version of Ring you want to use, but in the absence of that, I think upgrading the default deps would be a good thing to do anyway.